### PR TITLE
Fix warnings

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -134,23 +134,6 @@ impl<'de, 'a> VariantAccess<'de> for EventsSequenceAccess<'a, 'de> {
 }
 
 
-struct YamlValueAccess<'a, 'de, Y: Iterator<Item = Yaml>> {
-    deserializer: &'a mut YamlDeserializer<'de>,
-    yaml: Y,
-}
-
-impl<'de, 'a, Y: Iterator<Item = Yaml>> SeqAccess<'de> for YamlValueAccess<'a, 'de, Y> {
-    type Error = serde::de::value::Error;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error> where T: DeserializeSeed<'de> {
-        if let Some(_) = self.yaml.next() {
-            seed.deserialize(&mut *self.deserializer).map(Some)
-        } else {
-            Ok(None)
-        }
-    }
-}
-
 macro_rules! deserialize_number {
     ($self:ident, $visitor:ident, $visit:ident, $type:ty) => {
         match $self.parser.next_token() {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -21,6 +21,7 @@ impl Display for MarkerWrapper {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
 enum Errors<'a> {
     #[error("Unexpected scalar value at position {2}. Expected: {0}, got: {1}")]
@@ -51,6 +52,7 @@ impl<'a> Errors<'a> {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl<'a> Into<serde::de::value::Error> for Errors<'a> {
     fn into(self) -> serde::de::value::Error {
         serde::de::value::Error::custom(self.to_string())
@@ -158,6 +160,7 @@ pub struct YamlDeserializer<'de> {
 }
 
 impl<'de> YamlDeserializer<'de> {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(data: &'de str) -> Result<Self, serde::de::value::Error> {
         let mut parser = Parser::new_from_str(data);
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -104,7 +104,7 @@ impl<'de, 'a> VariantAccess<'de> for EventsSequenceAccess<'a, 'de> {
 
     fn unit_variant(self) -> Result<(), Self::Error> {
         match self.deserializer.parser.next_token() {
-            Ok((Event::Scalar(value, _, ..), marker), ..) => {
+            Ok((Event::Scalar(value, ..), marker), ..) => {
                 if value == "null" || value == "~" {
                     Ok(())
                 } else {
@@ -357,7 +357,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut YamlDeserializer<'de> {
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de> {
         match self.parser.next_token() {
-            Ok((Event::Scalar(value, _, ..), ..), ..) => {
+            Ok((Event::Scalar(value, ..), ..), ..) => {
                 return visitor.visit_string(value);
             },
             Ok((event, marker)) => {
@@ -379,7 +379,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut YamlDeserializer<'de> {
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de> {
         match self.parser.peek() {
-            Ok((Event::Scalar(value, _, ..), ..), ..) => {
+            Ok((Event::Scalar(value, ..), ..), ..) => {
                 if value == "null" || value == "~" {
                     self.parser.next_token().map_err(|e| Errors::scan_error(*e.marker()).into())?;
                     visitor.visit_none()
@@ -388,7 +388,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut YamlDeserializer<'de> {
                 }
             },
             Ok((event, marker)) => {
-                Err(Errors::unexpected_event_error("Scalar", event.clone(), marker.clone()).into())
+                Err(Errors::unexpected_event_error("Scalar", event.clone(), *marker).into())
             },
             Err(scan_error) => {
                 Err(Errors::scan_error(*scan_error.marker()).into())
@@ -398,7 +398,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut YamlDeserializer<'de> {
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de> {
         match self.parser.next_token() {
-            Ok((Event::Scalar(value, _, ..), marker), ..) => {
+            Ok((Event::Scalar(value, ..), marker), ..) => {
                 if value == "null" || value == "~" {
                     visitor.visit_unit()
                 } else {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -49,7 +49,7 @@ fn write_indent(level: i32, writer: &mut dyn Write) -> Result<(), Errors> {
 }
 
 fn escape_str(source: &str) -> String {
-    source.replace("'", r#"\'"#)
+    source.replace('\'', r#"\'"#)
 }
 
 pub struct SequenceSerializer<'a, 'se> {
@@ -58,7 +58,7 @@ pub struct SequenceSerializer<'a, 'se> {
 }
 
 impl<'a, 'se> SequenceSerializer<'a, 'se> {
-    fn process_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Errors> where T: Serialize {
+    fn process_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Errors> {
         self.ser.writer.write_str("- \n")?;
         self.ser.incr_level();
         write_indent(self.ser.level, self.ser.writer)?;
@@ -81,7 +81,7 @@ impl<'a, 'se> SerializeSeq for SequenceSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.process_element(value)
     }
 
@@ -94,7 +94,7 @@ impl<'a, 'se> SerializeTuple for SequenceSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.process_element(value)
     }
 
@@ -107,7 +107,7 @@ impl<'a, 'se> SerializeTupleStruct for SequenceSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.process_element(value)
     }
 
@@ -120,7 +120,7 @@ impl<'a, 'se> SerializeTupleVariant for SequenceSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.process_element(value)
     }
 
@@ -141,14 +141,14 @@ pub struct MapSerializer<'a, 'se> {
 }
 
 impl<'a, 'se> MapSerializer<'a, 'se> {
-    fn process_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Errors> where T: Serialize {
+    fn process_key<T: Serialize + ?Sized>(&mut self, key: &T) -> Result<(), Errors> {
         T::serialize(key, &mut *self.ser)?;
         self.ser.writer.write_str(":\n")?;
         self.ser.incr_level();
         write_indent(self.ser.level, self.ser.writer)
     }
 
-    fn process_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Errors> where T: Serialize {
+    fn process_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Errors> {
         T::serialize(value, &mut *self.ser)?;
         self.ser.decr_level();
         self.ser.writer.write_char('\n')?;
@@ -164,11 +164,11 @@ impl<'a, 'se> SerializeMap for MapSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_key<T: Serialize + ?Sized>(&mut self, key: &T) -> Result<(), Self::Error> {
         self.process_key(key)
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.process_value(value)
     }
 
@@ -181,7 +181,7 @@ impl<'a, 'se> SerializeStruct for MapSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> {
         self.process_key(key)?;
         self.process_value(value)
     }
@@ -195,7 +195,7 @@ impl<'a, 'se> SerializeStructVariant for MapSerializer<'a, 'se> {
     type Ok = ();
     type Error = Errors;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> {
         self.process_key(key)?;
         self.process_value(value)
     }
@@ -343,7 +343,7 @@ impl<'a, 'se> Serializer for &'a mut YamlSerializer<'se> {
         Ok(())
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error> where T: Serialize {
+    fn serialize_some<T: Serialize + ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error> {
         value.serialize(self)
     }
 
@@ -360,12 +360,12 @@ impl<'a, 'se> Serializer for &'a mut YamlSerializer<'se> {
         self.serialize_none()
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok, Self::Error> where T: Serialize {
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok, Self::Error> {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(self, _name: &'static str, _variant_index: u32, variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error> where T: Serialize {
-        write!(self.writer, "{}:\n", variant)?;
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(self, _name: &'static str, _variant_index: u32, variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error> {
+        writeln!(self.writer, "{}:", variant)?;
         self.incr_level();
         write_indent(self.level, self.writer)?;
         let result = value.serialize(&mut *self);
@@ -401,7 +401,7 @@ impl<'a, 'se> Serializer for &'a mut YamlSerializer<'se> {
             write!(self.writer, "{}: ", variant)?;
             self.serialize_seq(Some(len))
         } else {
-            write!(self.writer, "{}:\n", variant)?;
+            writeln!(self.writer, "{}:", variant)?;
             self.incr_level();
             write_indent(self.level, self.writer)?;
             self.serialize_seq(Some(len))
@@ -419,7 +419,7 @@ impl<'a, 'se> Serializer for &'a mut YamlSerializer<'se> {
     }
 
     fn serialize_struct_variant(self, name: &'static str, _variant_index: u32, variant: &'static str, len: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
-        write!(self.writer, "{}:\n", variant)?;
+        writeln!(self.writer, "{}:", variant)?;
         self.incr_level();
         write_indent(self.level, self.writer)?;
         self.serialize_struct(name, len)

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -111,7 +111,7 @@ impl<'de> Visitor<'de> for YamlNodeWrapperVisitor {
 
 impl<'de> Deserialize<'de> for YamlNodeWrapper {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        deserializer.deserialize_any(YamlNodeWrapperVisitor {}).map(|i| YamlNodeWrapper(i))
+        deserializer.deserialize_any(YamlNodeWrapperVisitor {}).map(YamlNodeWrapper)
     }
 }
 
@@ -128,7 +128,7 @@ impl Serialize for YamlNodeWrapper {
                 serializer.serialize_i64(*v)
             },
             Yaml::String(v) => {
-                serializer.serialize_str(&v)
+                serializer.serialize_str(v)
             },
             Yaml::Boolean(v) => {
                 serializer.serialize_bool(*v)


### PR DESCRIPTION
Addressing warnings found by `cargo clippy --all-targets --all-features` with Rust 1.79.0.  These changes pass `cargo test` locally and works in a project where switching to `serde_yaml2` is being considered.