### PR TITLE
Fix deserialization of option. Allow list, struc, map... and not only scalar

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -390,8 +390,8 @@ impl<'de, 'a> Deserializer<'de> for &'a mut YamlDeserializer<'de> {
                     visitor.visit_some(self)
                 }
             },
-            Ok((event, marker)) => {
-                Err(Errors::unexpected_event_error("Scalar", event.clone(), *marker).into())
+            Ok((_event, _marker)) => {
+                visitor.visit_some(self)
             },
             Err(scan_error) => {
                 Err(Errors::scan_error(*scan_error.marker()).into())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,24 +12,42 @@ fn deserialize() {
     }
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
+    struct SubTestStruct {
+        a: String
+    }
+
+    #[derive(Deserialize, Serialize, Debug, PartialEq)]
     struct TestStruct {
+        u: SubTestStruct,
+        v: Option<Vec<String>>,
+        w: Vec<String>,
         x: i64,
         y: String,
         z: Vec<i32>,
     }
 
-    let result: TestStruct = from_str("x: -41\ny: Hello world\nz: [1,2,3]\n").unwrap();
+    let result: TestStruct = from_str("u:\n  a: \"Nice!\"\nv: [\"a\", \"b\"]\nw: [\"a\", \"b\"]\nx: -41\ny: Hello world\nz: [1,2,3]\n").unwrap();
 
     assert_eq!(TestStruct {
+        u: SubTestStruct {
+            a: String::from("Nice!")
+        },
+        v: Some(vec![String::from("a"),String::from("b")]),
+        w: vec![String::from("a"),String::from("b")],
         x: -41,
         y: "Hello world".to_owned(),
         z: vec![1,2,3],
     }, result);
 
     let result = to_string(result).unwrap();
-    assert_eq!("'x':\n  -41\n'y':\n  'Hello world'\n'z':\n  - \n   1\n  - \n   2\n  - \n   3\n  \n", result);
+    assert_eq!("'u':\n  'a':\n   'Nice!'\n  \n'v':\n  - \n   'a'\n  - \n   'b'\n  \n'w':\n  - \n   'a'\n  - \n   'b'\n  \n'x':\n  -41\n'y':\n  'Hello world'\n'z':\n  - \n   1\n  - \n   2\n  - \n   3\n  \n", result);
 
     assert_eq!(TestStruct {
+        u: SubTestStruct {
+            a: String::from("Nice!")
+        },
+        v: Some(vec![String::from("a"),String::from("b")]),
+        w: vec![String::from("a"),String::from("b")],
         x: -41,
         y: "Hello world".to_owned(),
         z: vec![1,2,3],


### PR DESCRIPTION
Hello,

Actually, when you have Option<T> field, T must be a scalar. If you have Option<Vec<T>>, you got:
```
called `Result::unwrap()` on an `Err` value: Error("Unexpected event at position Line: 3, Column: 3, Index: 19. Expected: Scalar, got: SequenceStart(0, None)")
```

With this fix, Option<T> can be a struct, list, map...